### PR TITLE
Run /Disable-Feature with /NoRestart option

### DIFF
--- a/lib/puppet/provider/dism/dism.rb
+++ b/lib/puppet/provider/dism/dism.rb
@@ -47,7 +47,13 @@ Puppet::Type.type(:dism).provide(:dism) do
   end
 
   def destroy
-    dism '/online', '/Disable-Feature', "/FeatureName:#{resource[:name]}"
+    if ENV.has_key?('ProgramFiles(x86)')
+      dism_cmd = "#{Dir::WINDOWS}\\sysnative\\Dism.exe"
+    else
+      dism_cmd = "#{Dir::WINDOWS}\\system32\\Dism.exe"
+    end
+    output = execute([dism_cmd, '/online', '/Disable-Feature', "/FeatureName:#{resource[:name]}", '/NoRestart'], :failonfail => false)
+    raise Puppet::Error, "Unexpected exitcode: #{$?.exitstatus}\nError:#{output}" unless resource[:exitcode].include? $?.exitstatus
   end
 
   def currentstate


### PR DESCRIPTION
Running `/Disable-Feature` often exits with same 3010 "error" code ("restart required") as `/Enable-Feature`.
This patch adds `/NoRestart` option to DISM command line and checks exit status code according to `exitcode` `dism` type parameter.

P.S. Obviously code that determines correct dism.exe path should be moved to separate function (`dism_cmd = ...`), but I'm not familiar with Ruby and Puppet internals to do it carefully.
