### PR TITLE
Support 32 bit and 'reboot on uninstall' scenarios

### DIFF
--- a/lib/puppet/provider/dism/dism.rb
+++ b/lib/puppet/provider/dism/dism.rb
@@ -47,7 +47,13 @@ Puppet::Type.type(:dism).provide(:dism) do
   end
 
   def destroy
-    dism '/online', '/Disable-Feature', "/FeatureName:#{resource[:name]}"
+    if ENV.has_key?('ProgramFiles(x86)')
+      dism_cmd = "#{Dir::WINDOWS}\\sysnative\\Dism.exe"
+    else
+      dism_cmd = "#{Dir::WINDOWS}\\system32\\Dism.exe"
+    end
+    output = execute([dism_cmd, '/online', '/Disable-Feature', "/FeatureName:#{resource[:name]}", '/NoRestart'], :failonfail => false)
+    raise Puppet::Error, "Unexpected exitcode: #{$?.exitstatus}\nError:#{output}" unless resource[:exitcode].include? $?.exitstatus
   end
 
   def currentstate

--- a/lib/puppet/type/dism.rb
+++ b/lib/puppet/type/dism.rb
@@ -24,7 +24,7 @@ Puppet::Type.newtype(:dism) do
   end
 
   newparam(:exitcode, :array_matching => :all) do
-    desc "DISM installation process exit code"
-    defaultto([0, 3010])
+    desc "DISM installation process exit code (optional)"
+    defaultto([0, 3010, 3010 & 0xFF])
   end
 end


### PR DESCRIPTION
This is a pull request to support return codes from dism command on 32-bit versions of Ruby and to deal with those codes in the destroy method (some uninstalls result in reboot requests similar to installs).
