### PR TITLE
Fix ensurable so it works with PE 2015.2, tested as working on 3.8

### DIFF
--- a/lib/puppet/type/dism.rb
+++ b/lib/puppet/type/dism.rb
@@ -1,19 +1,7 @@
 Puppet::Type.newtype(:dism) do
   @doc = 'Manages Windows features via dism.'
 
-  ensurable do
-    desc 'Windows feature install state.'
-
-    defaultvalues
-
-    newvalue(:present) do
-      provider.create
-    end
-
-    newvalue(:absent) do
-      provider.destroy
-    end
-  end
+  ensurable
 
   newparam(:name, :namevar => true) do
     desc 'The Windows feature name (case-sensitive).'


### PR DESCRIPTION
The ensurable bracket was breaking the module when run under PE 2015.2. 

I've confirmed this change still works on PE 3.8 as well.

(Change was recommended by Brett Gray).