### PR TITLE
(MODULES-2493) Add source and limitaccess params

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The module requires that dism be installed on your system, in most cases this wi
     dism { 'NetFx3':
       ensure => present,
       all => true,
+      source  => 'Z:\2012r2\sxs'
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ The module requires that dism be installed on your system, in most cases this wi
 * `answer`: The answer file that you would like to pass to dism.exe to provide any answers.
 * `norestart`: Whether to explicitly tell the provider to NOT restart.  Defaults to false.
 * `exitcodes`: Acceptable exit codes. Defaults to [0, 3010]
+* `source`: Filepath to the source files needed for installing the feature.
+* `limitaccess`: Prevent DISM from contacting WU for repair of online images. Defaults to false
 
 
 

--- a/lib/puppet/provider/dism/dism.rb
+++ b/lib/puppet/provider/dism/dism.rb
@@ -41,10 +41,16 @@ Puppet::Type.type(:dism).provide(:dism) do
     end
     cmd << "/FeatureName:#{resource[:name]}"
     cmd << '/Quiet'
+    if resource[:source]
+      cmd << "/Source:'#{resource[:source]}'"
+    end
     if resource[:answer]
       cmd << "/Apply-Unattend:#{resource[:answer]}"
     end
-    if resource[:norestart] == :true
+    if resource[:limitaccess] && resource[:source]
+      cmd << '/LimitAccess'
+    end
+   if resource[:norestart] == :true
       cmd << '/NoRestart'
     end
     output = execute(cmd, :failonfail => false)

--- a/lib/puppet/type/dism.rb
+++ b/lib/puppet/type/dism.rb
@@ -11,6 +11,20 @@ Puppet::Type.newtype(:dism) do
     desc 'The answer file for installing the feature.'
   end
 
+  newparam(:source) do
+    desc "The source files needed for installing the feature."
+  end
+  
+  newparam(:limitaccess) do
+    desc "Prevent DISM from contacting Windows Update for repair of online images"
+    newvalues(:true, :false)
+    defaultto(false)
+    
+    munge do |value|
+      resource.munge_boolean(value)
+    end
+  end
+  
   newparam(:all) do
     desc 'A flag indicating if we should install all dependencies or not.'
     newvalues(:true, :false)

--- a/spec/unit/provider/dism_spec.rb
+++ b/spec/unit/provider/dism_spec.rb
@@ -19,9 +19,16 @@ RSpec.describe provider_class do
       cmd << "/FeatureName:#{params[:name]}"
       cmd << '/Quiet'
 
+      if params.has_key?(:source)
+        cmd << "/Source:'#{params[:source]}'"
+      end
+      if params.has_key?(:limitaccess) && params[:limitaccess] == true && params.has_key?(:source)
+        cmd << '/LimitAccess'
+      end
       if (params.has_key?(:norestart) && params[:norestart] == true) || !(params.has_key?(:norestart))
         cmd << '/NoRestart'
       end
+
 
       Puppet::Util::Execution.stubs(:execute).with(
         cmd, {:failonfail => false}
@@ -78,6 +85,23 @@ RSpec.describe provider_class do
           :name => 'NetFx3',
           :all => true,
           :norestart => true
+        } }
+      end
+    end
+    context 'with source' do
+      it_behaves_like 'valid enable compile' do
+        let(:params) { {
+            :name => 'netFx3',
+            :source => 'C:\\myInstall.cab'
+        } }
+      end
+    end
+    context 'limitaccess' do
+      it_behaves_like 'valid enable compile' do
+        let(:params) { {
+            :name => 'netFx3',
+            :source => 'C:\\myInstall.cab',
+            :limitaccess => true,
         } }
       end
     end


### PR DESCRIPTION
- Usage updated with new source param

- Added new param to specify source.

When specifying source, /LimitAccess will be used to prevent DISM from
contacting Windows Update.

- New param limitaccess.

- Defaults to true when source is specified.

- Split source and limitaccess params.

- Default is to add /LimitAccess when source is specified in the manifest.

- Make /LimitAccess relevant only when source is set