### PR TITLE
fixed issue with ":all" parameter.

### DIFF
--- a/lib/puppet/provider/dism/dism.rb
+++ b/lib/puppet/provider/dism/dism.rb
@@ -36,7 +36,7 @@ Puppet::Type.type(:dism).provide(:dism) do
 
   def create
     cmd = [command(:dism), '/online', '/Enable-Feature']
-    if resource[:all]
+    if resource[:all] == :true
       cmd << '/All'
     end
     cmd << "/FeatureName:#{resource[:name]}"
@@ -47,7 +47,7 @@ Puppet::Type.type(:dism).provide(:dism) do
     if resource[:answer]
       cmd << "/Apply-Unattend:#{resource[:answer]}"
     end
-    if resource[:limitaccess] && resource[:source]
+    if resource[:limitaccess] == :true && resource[:source]
       cmd << '/LimitAccess'
     end
    if resource[:norestart] == :true


### PR DESCRIPTION
This resolves an issue in Windows 2008 R2 where if you specify "all => false" for a dism resource it would fail with the error:
Error: /Stage[main]/Ko_iis/Dism[IIS-WebServerRole]/ensure: change from absent to present failed: Unexpected exitcode: 87
Error:
Error: 87

The all option is not recognized in this context.
For more information, refer to the help.